### PR TITLE
genericizing zamboni-dashboard

### DIFF
--- a/zamboni_dashboard/default_settings.py
+++ b/zamboni_dashboard/default_settings.py
@@ -1,4 +1,7 @@
 class DefaultSettings(object):
+    DASHBOARD_NAME = 'Zamboni Dashboard'
+    OPS_BUG_URL = 'https://bit.ly/amo_ops_bug'
+    OPS_DOCS_URL = 'https://mana.mozilla.org/wiki/display/websites/addons.mozilla.org'
     GANGLIA_BASE = 'https://ganglia.mozilla.org/phx1'
     GRAPHITE_BASE = 'https://graphite-phx.mozilla.org'
     NAGIOS_STATUS_FILE = ''

--- a/zamboni_dashboard/templates/base.html
+++ b/zamboni_dashboard/templates/base.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{% block title %}Zamboni Dashboard{% endblock %}</title>
+        <title>{% block title %}{{config.DASHBOARD_NAME}}{% endblock %}</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" />
         <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
         <script src="{{ url_for('static', filename='js/jquery-1.7.2.min.js') }}"></script>
@@ -18,7 +18,7 @@
         <div class="navbar navbar-fixed-top">
             <div class="navbar-inner">
                 <div class="container">
-                    <a class="brand" href="#">Zamboni Dashboard</a>
+                    <a class="brand" href="#">{{config.DASHBOARD_NAME}}</a>
                     <ul class="nav">
                         <li><a href="{{ url_for('index') }}">Home</a></li>
                         <li><a href="{{ url_for('ganglia') }}">Ganglia</a></li>
@@ -28,8 +28,8 @@
                         <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">External<b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                            <li><a href="https://bit.ly/amo_ops_bug">File an operations bug</a></li>
-                            <li><a href="https://mana.mozilla.org/wiki/display/websites/addons.mozilla.org">Operations documentation</a></li>
+                            <li><a href="{{config.OPS_BUG_URL}}">File an operations bug</a></li>
+                            <li><a href="{{config.OPS_DOCS_URL}}">Operations documentation</a></li>
                         </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
I started changing a couple of cosmetic zamboni-specific items in the dashboard (like the title, name, bug url and docs url) and turned them into config options.  The default settings are what they were so this should not effect the current zamboni dashboard but allow different uses through settings_local.

I didn't change much since I'm a n00b at the fork and pull game, so let me know if this is wrong or undesired.
