### PR TITLE
splitting ganglia out

### DIFF
--- a/zamboni_dashboard/data/ganglia.py
+++ b/zamboni_dashboard/data/ganglia.py
@@ -1,0 +1,17 @@
+from .. import app
+from urllib import urlencode
+
+def ganglia_graphs(names, *args, **kwargs):
+    return [ganglia_graph(n, *args, **kwargs) for n in names]
+
+def ganglia_graph(name, cluster, size='medium',
+                        r='hour', t='g', host=None):
+    query = {'c': cluster,
+             'z': size,
+             'r': r,
+             t: name}
+    if host:
+        query['host'] = host
+
+    return "%s/graph.php?%s" % (app.config['GANGLIA_BASE'],
+                                urlencode(query))

--- a/zamboni_dashboard/default_settings.py
+++ b/zamboni_dashboard/default_settings.py
@@ -1,4 +1,7 @@
 class DefaultSettings(object):
+    DASHBOARD_NAME = 'Zamboni Dashboard'
+    OPS_BUG_URL = 'https://bit.ly/amo_ops_bug'
+    OPS_DOCS_URL = 'https://mana.mozilla.org/wiki/display/websites/addons.mozilla.org'
     GANGLIA_BASE = 'https://ganglia.mozilla.org/phx1'
     GRAPHITE_BASE = 'https://graphite-phx.mozilla.org'
     NAGIOS_STATUS_FILE = ''

--- a/zamboni_dashboard/default_settings.py
+++ b/zamboni_dashboard/default_settings.py
@@ -3,6 +3,8 @@ class DefaultSettings(object):
     OPS_BUG_URL = 'https://bit.ly/amo_ops_bug'
     OPS_DOCS_URL = 'https://mana.mozilla.org/wiki/display/websites/addons.mozilla.org'
     GANGLIA_BASE = 'https://ganglia.mozilla.org/phx1'
+    GANGLIA_DEFAULT_REPORTS = ['load_report', 'cpu_report',
+                       'mem_report', 'network_report']
     GRAPHITE_BASE = 'https://graphite-phx.mozilla.org'
     NAGIOS_STATUS_FILE = ''
     NAGIOS_STATUS_URL = ''

--- a/zamboni_dashboard/templates/base.html
+++ b/zamboni_dashboard/templates/base.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{% block title %}Zamboni Dashboard{% endblock %}</title>
+        <title>{% block title %}{{config.DASHBOARD_NAME}}{% endblock %}</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" />
         <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
         <script src="{{ url_for('static', filename='js/jquery-1.7.2.min.js') }}"></script>
@@ -18,7 +18,7 @@
         <div class="navbar navbar-fixed-top">
             <div class="navbar-inner">
                 <div class="container">
-                    <a class="brand" href="#">Zamboni Dashboard</a>
+                    <a class="brand" href="#">{{config.DASHBOARD_NAME}}</a>
                     <ul class="nav">
                         <li><a href="{{ url_for('index') }}">Home</a></li>
                         <li><a href="{{ url_for('ganglia') }}">Ganglia</a></li>
@@ -28,8 +28,8 @@
                         <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">External<b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                            <li><a href="https://bit.ly/amo_ops_bug">File an operations bug</a></li>
-                            <li><a href="https://mana.mozilla.org/wiki/display/websites/addons.mozilla.org">Operations documentation</a></li>
+                            <li><a href="{{config.OPS_BUG_URL}}">File an operations bug</a></li>
+                            <li><a href="{{config.OPS_DOCS_URL}}">Operations documentation</a></li>
                         </ul>
                         </li>
                     </ul>

--- a/zamboni_dashboard/templates/base.html
+++ b/zamboni_dashboard/templates/base.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{% block title %}{{config.DASHBOARD_NAME}}{% endblock %}</title>
+        <title>{% block title %}{{ config.DASHBOARD_NAME }}{% endblock %}</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" />
         <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
         <script src="{{ url_for('static', filename='js/jquery-1.7.2.min.js') }}"></script>
@@ -18,7 +18,7 @@
         <div class="navbar navbar-fixed-top">
             <div class="navbar-inner">
                 <div class="container">
-                    <a class="brand" href="#">{{config.DASHBOARD_NAME}}</a>
+                    <a class="brand" href="#">{{ config.DASHBOARD_NAME }}</a>
                     <ul class="nav">
                         <li><a href="{{ url_for('index') }}">Home</a></li>
                         <li><a href="{{ url_for('ganglia') }}">Ganglia</a></li>


### PR DESCRIPTION
ganglia is split out in /data/ and acts a bit more like nagios.py, also worked it up so ganglia is configurable and not amo-specific.

added the following config options:

GANGLIA_DEFAULT_REPORTS replaced default_reports before
GANGLIA_GROUPS defines the groups to be displayed, a bit like nagios behaves. For example, see default_settings.py  (I'll add details to the readme in the next commit)

(also added spaces for my last pull request per tip from cvan)
