### PR TITLE
Improve Zamboni API Dashboard (bug 963072)

### DIFF
--- a/zamboni_dashboard/static/css/style.css
+++ b/zamboni_dashboard/static/css/style.css
@@ -1,0 +1,13 @@
+.graphs-container {
+    background-color: black;
+}
+
+.graphs-selector {
+    list-style-type: none;
+    margin: 0;
+}
+
+.graphs-selector ul, .graphs-selector ul li {
+    display: inline;
+    margin: 0;
+}

--- a/zamboni_dashboard/templates/graphite.html
+++ b/zamboni_dashboard/templates/graphite.html
@@ -7,16 +7,21 @@
     {% endfor %}
   </p>
   <hr/>
-  <p>
-    {% for slug, name, graph in graphs %}
-      <a href="?site={{ defaults.site }}&amp;graph={{ slug }}">{{ name }}</a> {% if not loop.last %}|{% endif %}
-    {% endfor %}
-  </p>
-    <h2><a id="{{ graph.slug }}">{{ graph.name }}</a></h2>
-    <img class="fifteen" src="{{ base }}&amp;{{ graph.url[0] }}{{ graph.updates }}&amp;{{ fifteen }}&amp;{{ thresholds }}">
-    <img class="hour" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ hour }}&amp;{{ thresholds }}">
-    <img class="day" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ day }}&amp;{{ thresholds }}">
-    <img class="week" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ week }}&amp;{{ thresholds }}">
-    <img class="month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ month }}&amp;{{ thresholds }}">
-    <img class="3month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ three_month }}&amp;{{ thresholds }}">
+  <ul class="graphs-selector">
+  {% for group in graphs.values()|groupby('prefix') %}
+      <li>{{ group.grouper }}{% if group.grouper %}: {% endif %}<ul>
+      {% for graph in group.list %}
+          <li><a href="?site={{ defaults.site }}&amp;graph={{ graph.slug }}">{{ graph.suffix }}</a> {% if not loop.last %}|{% endif %}</li>
+      {% endfor %}</ul></li>
+  {% endfor %}
+  </ul>
+  <h2><a id="{{ current_graph.slug }}">{{ current_graph.name }}</a></h2>
+  <div class="graphs-container">
+    <img class="fifteen" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ fifteen }}&amp;{{ thresholds }}">
+    <img class="hour" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ hour }}&amp;{{ thresholds }}">
+    <img class="day" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ day }}&amp;{{ thresholds }}">
+    <img class="week" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ week }}&amp;{{ thresholds }}">
+    <img class="month" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ month }}&amp;{{ thresholds }}">
+    <img class="3month" src="{{ base }}&amp;{{ current_graph.url[0] }}{{ current_graph.updates }}&amp;{{ three_month }}&amp;{{ thresholds }}">
+  </div>
 {% endblock %}

--- a/zamboni_dashboard/templates/graphite.html
+++ b/zamboni_dashboard/templates/graphite.html
@@ -13,10 +13,10 @@
     {% endfor %}
   </p>
     <h2><a id="{{ graph.slug }}">{{ graph.name }}</a></h2>
-    <img class="fifteen" src="{{ base }}&amp;{{ graph.url[0] }}{{ graph.updates }}&amp;{{ fifteen }}{{ thresholds }}"">
-    <img class="hour" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ hour }}{{ thresholds }}"">
-    <img class="day" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ day }}{{ thresholds }}"">
-    <img class="week" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ week }}{{ thresholds }}">
-    <img class="month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ month }}{{ thresholds }}"">
-    <img class="3month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ three_month }}{{ thresholds }}"">
+    <img class="fifteen" src="{{ base }}&amp;{{ graph.url[0] }}{{ graph.updates }}&amp;{{ fifteen }}&amp;{{ thresholds }}">
+    <img class="hour" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ hour }}&amp;{{ thresholds }}">
+    <img class="day" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ day }}&amp;{{ thresholds }}">
+    <img class="week" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ week }}&amp;{{ thresholds }}">
+    <img class="month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ month }}&amp;{{ thresholds }}">
+    <img class="3month" src="{{ base }}&amp;{{ graph.url[0]  }}{{ graph.updates }}&amp;{{ three_month }}&amp;{{ thresholds }}">
 {% endblock %}

--- a/zamboni_dashboard/views.py
+++ b/zamboni_dashboard/views.py
@@ -101,8 +101,12 @@ def graphite_api():
     template_data = get_template_data(graphite_api_graphs, data, graph, site)
     # This only goes halfway across, we need a graphite update
     # for more. https://bugs.launchpad.net/graphite/+bug/1013308
-    template_data['thresholds'] = ('&target=threshold(500, "poor", orange)'
-                                   '&target=threshold(1000, "bad", red)')
+    targets = (
+        'threshold(500, "poor", orange)',
+        'threshold(1000, "bad", red)',
+        'drawAsInfinite(color(stats.timers.addons.update.count, "magenta"))'
+    )
+    template_data['thresholds'] = '&'.join('target=%s' % t for t in targets)
     return render_template('graphite.html', **template_data)
 
 

--- a/zamboni_dashboard/views.py
+++ b/zamboni_dashboard/views.py
@@ -66,14 +66,17 @@ def get_template_data(source, data, graph, site):
     graphs = {}
     for name, gs in source:
         slug = name.lower().replace(' ', '-')
+        partition = name.rpartition('.')
         graphs[slug] = {
-            'name': name, 'slug': slug,
+            'name': name,
+            'prefix': partition[0],
+            'suffix': partition[2],
+            'slug': slug,
             'url': [str(Template(g).render(data)) for g in gs],
             'updates': data['updates'],
         }
-
-    data['graphs'] = sorted([(v['slug'], v['name'], v['url']) for v in graphs.values()])
-    data['graph'] = graphs[graph]
+    data['graphs'] = graphs # sorted([(v['slug'], v['name'], v['url']) for v in graphs.values()])
+    data['current_graph'] = graphs[graph]
     data['defaults'] = {'site': site, 'graph': graph}
     return data
 


### PR DESCRIPTION
- Group APIs belonging to the same module
- Add vertical line corresponding to production pushes

**Before:**
![screen shot 2014-01-05 at 18 44 11](https://f.cloud.github.com/assets/187006/1987214/75b983ba-8456-11e3-916e-2bff91e02dd2.png)

**After:**
![screen shot 2014-01-05 at 18 46 53](https://f.cloud.github.com/assets/187006/1987215/75bc5db0-8456-11e3-9fbb-c9fe4681e727.png)
